### PR TITLE
Output can be formatted as ISO 8601

### DIFF
--- a/ricescheduler.py
+++ b/ricescheduler.py
@@ -29,7 +29,8 @@ def date_formats():
             ('Jan. 12', 'MMM. D'),
             ('January 12 (Tuesday)', 'MMMM D (dddd)'),
             ('1/12', 'M/D'),
-            ('01/12', 'MM/DD')]
+            ('01/12', 'MM/DD'),
+            ('2016-01-12', 'YYYY-MM-DD')]
     return date_formats
 
 def fetch_registrar_table(url):


### PR DESCRIPTION
The standard date format makes the resulting dates much easier to parse if needed. They can make the round trip into arrow unmodified.