### PR TITLE
Add 'Tue. Jan. 12' format with no comma after weekday.

### DIFF
--- a/ricescheduler.py
+++ b/ricescheduler.py
@@ -24,6 +24,7 @@ def date_formats():
             ('Tuesday, January 12', 'dddd, MMMM D'),
             ('Tue., Jan. 12, 2016', 'ddd., MMM. D, YYYY'),
             ('Tue., Jan. 12', 'ddd., MMM. D'),
+            ('Tue. Jan. 12', 'ddd. MMM. D'),
             ('January 12, 2016', 'MMMM D, YYYY'),
             ('January 12', 'MMMM D'),
             ('Jan. 12', 'MMM. D'),


### PR DESCRIPTION
Thanks for providing this nice tool - wonder if you'd consider adding this additional format, without a comma. 